### PR TITLE
* fixed: #7 java.nio.file.Paths.get returns Platform not recognized

### DIFF
--- a/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/fs/DefaultFileSystemProvider.java
@@ -55,18 +55,21 @@ public class DefaultFileSystemProvider {
      * Returns the default FileSystemProvider.
      */
     public static FileSystemProvider create() {
+        // RoboVm note: for everything using LinuxFileSystemProvider (creating directly)
         String osname = AccessController
             .doPrivileged(new GetPropertyAction("os.name"));
-        if (osname.equals("SunOS"))
-            return createProvider("sun.nio.fs.SolarisFileSystemProvider");
-        // Android-changed: Fuchsia: Use LinuxFileSystemProvider.
-        // if (osname.equals("Linux"))
-        if (osname.equals("Linux") || osname.equals("Fuchsia"))
-            return createProvider("sun.nio.fs.LinuxFileSystemProvider");
-        if (osname.contains("OS X"))
-            return createProvider("sun.nio.fs.MacOSXFileSystemProvider");
-        if (osname.equals("AIX"))
-            return createProvider("sun.nio.fs.AixFileSystemProvider");
+        if (osname.contains("OS X") || osname.equals("iOS") || osname.equals("iOS Simulator"))
+            return new LinuxFileSystemProvider();
+//        if (osname.equals("SunOS"))
+//            return createProvider("sun.nio.fs.SolarisFileSystemProvider");
+//        // Android-changed: Fuchsia: Use LinuxFileSystemProvider.
+//        // if (osname.equals("Linux"))
+//        if (osname.equals("Linux") || osname.equals("Fuchsia"))
+//            return createProvider("sun.nio.fs.LinuxFileSystemProvider");
+//        if (osname.contains("OS X"))
+//            return createProvider("sun.nio.fs.MacOSXFileSystemProvider");
+//        if (osname.equals("AIX"))
+//            return createProvider("sun.nio.fs.AixFileSystemProvider");
         throw new AssertionError("Platform not recognized");
     }
 }

--- a/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/fs/UnixNativeDispatcher.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/fs/UnixNativeDispatcher.java
@@ -32,6 +32,10 @@ import java.security.PrivilegedAction;
  * Unix system and library calls.
  */
 
+// RoboVM note: these dependencies required by native code, from native init()
+@org.robovm.rt.annotation.ForceLinkClass(UnixFileAttributes.class)
+@org.robovm.rt.annotation.ForceLinkClass(UnixFileStoreAttributes.class)
+@org.robovm.rt.annotation.ForceLinkClass(UnixMountEntry.class)
 class UnixNativeDispatcher {
     protected UnixNativeDispatcher() { }
 


### PR DESCRIPTION
Root case: there was no logic to create FileSystemProvider for ios/macosx
Fix: directly creating LinuxFileSystemProvider for RoboVM targets