### PR TITLE
* fixed: LC12 -- #13 ServerSocket crashes when setting its buffer size

### DIFF
--- a/compiler/rt/android/cmake/libcore/generate_constants.sh
+++ b/compiler/rt/android/cmake/libcore/generate_constants.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Generates MacOSX SocketOptionRegistry.java from template 
+# FIXME: its going to be working only on Darwin OS (probably might have issues between macosx and ios)
+# FIXME: it will produce output that requres a bit of 
+
+set -e
+cp ../../libcore/ojluni/src/main/java/sun/nio/ch/SocketOptionRegistry.java.template SocketOptionRegistry.java.template.h
+clang -E  SocketOptionRegistry.java.template.h | grep -o "package sun\.nio\.ch.*" -A 10000 | sed 's/PREFIX_//' >  ../../libcore/ojluni/src/main/java/sun/nio/ch/SocketOptionRegistry.java
+rm SocketOptionRegistry.java.template.h

--- a/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/ch/SocketOptionRegistry.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/ch/SocketOptionRegistry.java
@@ -24,61 +24,62 @@
  * questions.
  *
  */
-// AUTOMATICALLY GENERATED FILE - DO NOT EDIT                                  
-package sun.nio.ch;                                                            
-import java.net.SocketOption;                                                  
-import java.net.StandardSocketOptions;                                         
-import java.net.ProtocolFamily;                                                
-import java.net.StandardProtocolFamily;                                        
-import java.util.Map;                                                          
-import java.util.HashMap;                                                      
-class SocketOptionRegistry {                                                   
-    private SocketOptionRegistry() { }                                         
-    private static class RegistryKey {                                         
-        private final SocketOption<?> name;                                    
-        private final ProtocolFamily family;                                   
-        RegistryKey(SocketOption<?> name, ProtocolFamily family) {             
-            this.name = name;                                                  
-            this.family = family;                                              
-        }                                                                      
-        public int hashCode() {                                                
-            return name.hashCode() + family.hashCode();                        
-        }                                                                      
-        public boolean equals(Object ob) {                                     
-            if (ob == null) return false;                                      
-            if (!(ob instanceof RegistryKey)) return false;                    
-            RegistryKey other = (RegistryKey)ob;                               
-            if (this.name != other.name) return false;                         
-            if (this.family != other.family) return false;                     
-            return true;                                                       
-        }                                                                      
-    }                                                                          
-    private static class LazyInitialization {                                  
-        static final Map<RegistryKey,OptionKey> options = options();           
-        private static Map<RegistryKey,OptionKey> options() {                  
-            Map<RegistryKey,OptionKey> map =                                   
-                new HashMap<RegistryKey,OptionKey>();                          
-            map.put(new RegistryKey(StandardSocketOptions.SO_BROADCAST, Net.UNSPEC), new OptionKey(1, 6));
-            map.put(new RegistryKey(StandardSocketOptions.SO_KEEPALIVE, Net.UNSPEC), new OptionKey(1, 9));
-            map.put(new RegistryKey(StandardSocketOptions.SO_LINGER, Net.UNSPEC), new OptionKey(1, 13));
-            map.put(new RegistryKey(StandardSocketOptions.SO_SNDBUF, Net.UNSPEC), new OptionKey(1, 7));
-            map.put(new RegistryKey(StandardSocketOptions.SO_RCVBUF, Net.UNSPEC), new OptionKey(1, 8));
-            map.put(new RegistryKey(StandardSocketOptions.SO_REUSEADDR, Net.UNSPEC), new OptionKey(1, 2));
-            map.put(new RegistryKey(StandardSocketOptions.TCP_NODELAY, Net.UNSPEC), new OptionKey(6, 1));
-            map.put(new RegistryKey(StandardSocketOptions.IP_TOS, StandardProtocolFamily.INET), new OptionKey(0, 1));
-            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_IF, StandardProtocolFamily.INET), new OptionKey(0, 32));
-            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_TTL, StandardProtocolFamily.INET), new OptionKey(0, 33));
-            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_LOOP, StandardProtocolFamily.INET), new OptionKey(0, 34));
-            map.put(new RegistryKey(StandardSocketOptions.IP_TOS, StandardProtocolFamily.INET6), new OptionKey(41, 67));
-            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_IF, StandardProtocolFamily.INET6), new OptionKey(41, 17));
-            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_TTL, StandardProtocolFamily.INET6), new OptionKey(41, 18));
-            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_LOOP, StandardProtocolFamily.INET6), new OptionKey(41, 19));
-            map.put(new RegistryKey(ExtendedSocketOption.SO_OOBINLINE, Net.UNSPEC), new OptionKey(1, 10));
-            return map;                                                        
-        }                                                                      
-    }                                                                          
-    public static OptionKey findOption(SocketOption<?> name, ProtocolFamily family) { 
-        RegistryKey key = new RegistryKey(name, family);                       
-        return LazyInitialization.options.get(key);                            
-    }                                                                          
-}                                                                              
+// AUTOMATICALLY GENERATED FILE - DO NOT EDIT
+// RoboVM Note: TODO: FIXME: it was generated for MacosX
+package sun.nio.ch;
+import java.net.SocketOption;
+import java.net.StandardSocketOptions;
+import java.net.ProtocolFamily;
+import java.net.StandardProtocolFamily;
+import java.util.Map;
+import java.util.HashMap;
+class SocketOptionRegistry {
+    private SocketOptionRegistry() { }
+    private static class RegistryKey {
+        private final SocketOption<?> name;
+        private final ProtocolFamily family;
+        RegistryKey(SocketOption<?> name, ProtocolFamily family) {
+            this.name = name;
+            this.family = family;
+        }
+        public int hashCode() {
+            return name.hashCode() + family.hashCode();
+        }
+        public boolean equals(Object ob) {
+            if (ob == null) return false;
+            if (!(ob instanceof RegistryKey)) return false;
+            RegistryKey other = (RegistryKey)ob;
+            if (this.name != other.name) return false;
+            if (this.family != other.family) return false;
+            return true;
+        }
+    }
+    private static class LazyInitialization {
+        static final Map<RegistryKey,OptionKey> options = options();
+        private static Map<RegistryKey,OptionKey> options() {
+            Map<RegistryKey,OptionKey> map =
+                new HashMap<RegistryKey,OptionKey>();
+            map.put(new RegistryKey(StandardSocketOptions.SO_BROADCAST, Net.UNSPEC), new OptionKey(0xffff, 0x0020));
+            map.put(new RegistryKey(StandardSocketOptions.SO_KEEPALIVE, Net.UNSPEC), new OptionKey(0xffff, 0x0008));
+            map.put(new RegistryKey(StandardSocketOptions.SO_LINGER, Net.UNSPEC), new OptionKey(0xffff, 0x0080));
+            map.put(new RegistryKey(StandardSocketOptions.SO_SNDBUF, Net.UNSPEC), new OptionKey(0xffff, 0x1001));
+            map.put(new RegistryKey(StandardSocketOptions.SO_RCVBUF, Net.UNSPEC), new OptionKey(0xffff, 0x1002));
+            map.put(new RegistryKey(StandardSocketOptions.SO_REUSEADDR, Net.UNSPEC), new OptionKey(0xffff, 0x0004));
+            map.put(new RegistryKey(StandardSocketOptions.TCP_NODELAY, Net.UNSPEC), new OptionKey(6, 0x01));
+            map.put(new RegistryKey(StandardSocketOptions.IP_TOS, StandardProtocolFamily.INET), new OptionKey(0, 3));
+            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_IF, StandardProtocolFamily.INET), new OptionKey(0, 9));
+            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_TTL, StandardProtocolFamily.INET), new OptionKey(0, 10));
+            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_LOOP, StandardProtocolFamily.INET), new OptionKey(0, 11));
+            map.put(new RegistryKey(StandardSocketOptions.IP_TOS, StandardProtocolFamily.INET6), new OptionKey(41, 36));
+            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_IF, StandardProtocolFamily.INET6), new OptionKey(41, 9));
+            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_TTL, StandardProtocolFamily.INET6), new OptionKey(41, 10));
+            map.put(new RegistryKey(StandardSocketOptions.IP_MULTICAST_LOOP, StandardProtocolFamily.INET6), new OptionKey(41, 11));
+            map.put(new RegistryKey(ExtendedSocketOption.SO_OOBINLINE, Net.UNSPEC), new OptionKey(0xffff, 0x0100));
+            return map;
+        }
+    }
+    public static OptionKey findOption(SocketOption<?> name, ProtocolFamily family) {
+        RegistryKey key = new RegistryKey(name, family);
+        return LazyInitialization.options.get(key);
+    }
+}

--- a/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/ch/SocketOptionRegistry.java.template
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/sun/nio/ch/SocketOptionRegistry.java.template
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+@@END_COPYRIGHT@@
+
+#include <stdio.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#endif
+
+/* Defines SO_REUSEPORT */
+#if !defined(SO_REUSEPORT)
+#ifdef _WIN32
+#define SO_REUSEPORT 0
+#elif __linux__
+#define SO_REUSEPORT 15
+#elif __solaris__
+#define SO_REUSEPORT 0x100e
+#elif defined(AIX) || defined(MACOSX)
+#define SO_REUSEPORT 0x0200
+#else
+#define SO_REUSEPORT 0
+#endif
+#endif
+
+/* On Solaris, "sun" is defined as a macro. Undefine to make package
+   declaration valid */
+#undef sun
+
+/* To be able to name the Java constants the same as the C constants without
+   having the preprocessor rewrite those identifiers, add PREFIX_ to all
+   identifiers matching a C constant. The PREFIX_ is filtered out in the
+   makefile. */
+
+@@START_HERE@@
+
+package sun.nio.ch;
+import java.net.SocketOption;
+import java.net.StandardSocketOptions;
+import java.net.ProtocolFamily;
+import java.net.StandardProtocolFamily;
+import java.util.Map;
+import java.util.HashMap;
+class SocketOptionRegistry {
+
+    private SocketOptionRegistry() { }
+
+    private static class RegistryKey {
+        private final SocketOption<?> name;
+        private final ProtocolFamily family;
+        RegistryKey(SocketOption<?> name, ProtocolFamily family) {
+            this.name = name;
+            this.family = family;
+        }
+        public int hashCode() {
+            return name.hashCode() + family.hashCode();
+        }
+        public boolean equals(Object ob) {
+            if (ob == null) return false;
+            if (!(ob instanceof RegistryKey)) return false;
+            RegistryKey other = (RegistryKey)ob;
+            if (this.name != other.name) return false;
+            if (this.family != other.family) return false;
+            return true;
+        }
+    }
+
+    private static class LazyInitialization {
+
+        static final Map<RegistryKey,OptionKey> options = options();
+
+        private static Map<RegistryKey,OptionKey> options() {
+            Map<RegistryKey,OptionKey> map =
+                new HashMap<RegistryKey,OptionKey>();
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_BROADCAST,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_BROADCAST));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_KEEPALIVE,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_KEEPALIVE));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_LINGER,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_LINGER));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_SNDBUF,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_SNDBUF));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_RCVBUF,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_RCVBUF));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_REUSEADDR,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_REUSEADDR));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_SO_REUSEPORT,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_REUSEPORT));
+            // IPPROTO_TCP is 6
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_TCP_NODELAY,
+                Net.UNSPEC), new OptionKey(6, TCP_NODELAY));
+
+            // IPPROTO_IP is 0
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_TOS,
+                StandardProtocolFamily.INET), new OptionKey(0, IP_TOS));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_IF,
+                StandardProtocolFamily.INET), new OptionKey(0, IP_MULTICAST_IF));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_TTL,
+                StandardProtocolFamily.INET), new OptionKey(0, IP_MULTICAST_TTL));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_LOOP,
+                StandardProtocolFamily.INET), new OptionKey(0, IP_MULTICAST_LOOP));
+
+#ifdef AF_INET6
+            // IPPROTO_IPV6 is 41
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_TOS,
+                StandardProtocolFamily.INET6), new OptionKey(41, IPV6_TCLASS));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_IF,
+                StandardProtocolFamily.INET6), new OptionKey(41, IPV6_MULTICAST_IF));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_TTL,
+                StandardProtocolFamily.INET6), new OptionKey(41, IPV6_MULTICAST_HOPS));
+            map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_LOOP,
+                StandardProtocolFamily.INET6), new OptionKey(41, IPV6_MULTICAST_LOOP));
+#endif
+
+            map.put(new RegistryKey(ExtendedSocketOption.PREFIX_SO_OOBINLINE,
+                Net.UNSPEC), new OptionKey(SOL_SOCKET, SO_OOBINLINE));
+            return map;
+        }
+    }
+
+    public static OptionKey findOption(SocketOption<?> name, ProtocolFamily family) {
+        RegistryKey key = new RegistryKey(name, family);
+        return LazyInitialization.options.get(key);
+    }
+}


### PR DESCRIPTION
Fixes #13
RootCase: SocketOptionRegistry contained constant for Linux.
Fix: regenerated with values for MacosX