### PR TITLE
* fixed: #16 ByteBuffer's covariant methods don't work

### DIFF
--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/ByteBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/ByteBuffer.java
@@ -805,47 +805,55 @@ public abstract class ByteBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public ByteBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public ByteBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public ByteBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public ByteBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public ByteBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public ByteBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = ByteBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public ByteBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/CharBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/CharBuffer.java
@@ -863,47 +863,55 @@ public abstract class CharBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public CharBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public CharBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public CharBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public CharBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public CharBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public CharBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = CharBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public CharBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/DoubleBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/DoubleBuffer.java
@@ -637,47 +637,55 @@ public abstract class DoubleBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public DoubleBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public DoubleBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public DoubleBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public DoubleBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public DoubleBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public DoubleBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = DoubleBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public DoubleBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/FloatBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/FloatBuffer.java
@@ -637,47 +637,55 @@ public abstract class FloatBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public FloatBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public FloatBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public FloatBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public FloatBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public FloatBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public FloatBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = FloatBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public FloatBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/IntBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/IntBuffer.java
@@ -638,47 +638,55 @@ public abstract class IntBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public IntBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public IntBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public IntBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public IntBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public IntBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public IntBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = IntBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public IntBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/LongBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/LongBuffer.java
@@ -637,47 +637,55 @@ public abstract class LongBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public LongBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public LongBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public LongBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public LongBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public LongBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public LongBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = LongBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public LongBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/ShortBuffer.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/nio/ShortBuffer.java
@@ -637,47 +637,55 @@ public abstract class ShortBuffer
         return offset;
     }
 
+    // RoboVM Note: using covariant return types directly
     // BEGIN Android-added: covariant overloads of *Buffer methods that return this.
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer position(int newPosition) {
-        return super.position(newPosition);
+    public ShortBuffer position(int newPosition) {
+        super.position(newPosition);
+        return this;
     }
 
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer limit(int newLimit) {
-        return super.limit(newLimit);
+    public ShortBuffer limit(int newLimit) {
+        super.limit(newLimit);
+        return this;
     }
 
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer mark() {
-        return super.mark();
+    public ShortBuffer mark() {
+        super.mark();
+        return this;
     }
 
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer reset() {
-        return super.reset();
+    public ShortBuffer reset() {
+        super.reset();
+        return this;
     }
 
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer clear() {
-        return super.clear();
+    public ShortBuffer clear() {
+        super.clear();
+        return this;
     }
 
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer flip() {
-        return super.flip();
+    public ShortBuffer flip() {
+        super.flip();
+        return this;
     }
 
     @CovariantReturnType(returnType = ShortBuffer.class, presentAfter = 28)
     @Override
-    public Buffer rewind() {
-        return super.rewind();
+    public ShortBuffer rewind() {
+        super.rewind();
+        return this;
     }
     // END Android-added: covariant overloads of *Buffer methods that return this.
 

--- a/compiler/rt/android/libcore/ojluni/src/main/java/java/util/concurrent/ConcurrentHashMap.java
+++ b/compiler/rt/android/libcore/ojluni/src/main/java/java/util/concurrent/ConcurrentHashMap.java
@@ -1241,9 +1241,11 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      *
      * @return the set view
      */
+    // RoboVM Note: using covariant return types directly
     // Android-changed: Return type for backwards compat. Was KeySetView<K,V>. http://b/28099367
     @dalvik.annotation.codegen.CovariantReturnType(returnType = KeySetView.class, presentAfter = 28)
-    public Set<K> keySet() {
+    @Override
+    public KeySetView<K,V> keySet() {
         KeySetView<K,V> ks;
         return (ks = keySet) != null ? ks : (keySet = new KeySetView<K,V>(this, null));
     }


### PR DESCRIPTION
Fixes #16 
Root case: Android maintained java7 return types in sources and applies expected one during code gen. at our side its easy way to fix it at source level