### PR TITLE
* BuildType options for Framework target

### DIFF
--- a/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -195,6 +195,7 @@ public class Config {
 
     private boolean clean = false;
     private boolean debug = false;
+    private boolean registerDarwinExceptionHandler = false;
     private boolean useDebugLibs = false;
     private boolean skipLinking = false;
     private boolean skipInstall = false;
@@ -333,6 +334,10 @@ public class Config {
 
     public boolean isDebug() {
         return debug;
+    }
+
+    public boolean isRegisterDarwinExceptionHandler() {
+        return registerDarwinExceptionHandler;
     }
 
     public boolean isUseDebugLibs() {
@@ -1342,6 +1347,11 @@ public class Config {
 
         public Builder debug(boolean b) {
             config.debug = b;
+            return this;
+        }
+
+        public Builder registerDarwinExceptionHandler(boolean b) {
+            config.registerDarwinExceptionHandler = b;
             return this;
         }
 

--- a/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
+++ b/compiler/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java
@@ -111,7 +111,7 @@ public abstract class AbstractTarget implements Target {
         } else {
             libs.addAll(Arrays.asList("-Wl,--whole-archive", "-lrobovm-rt" + libSuffix, "-Wl,--no-whole-archive"));
         }
-        if (config.isSkipInstall()) {
+        if (config.isDebug() || config.isRegisterDarwinExceptionHandler()) {
             libs.add("-lrobovm-debug" + libSuffix);
         }
         libs.addAll(Arrays.asList(
@@ -155,7 +155,7 @@ public abstract class AbstractTarget implements Target {
         } else if (config.getOs().getFamily() == OS.Family.darwin) {
             ccArgs.add("-ObjC");
 
-            if (config.isSkipInstall()) {
+            if (config.isDebug() || config.isRegisterDarwinExceptionHandler()) {
                 exportedSymbols.add("catch_exception_raise");
             }
             for (int i = 0; i < exportedSymbols.size(); i++) {

--- a/compiler/vm/core/src/CMakeLists.txt
+++ b/compiler/vm/core/src/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SRC
 
 if(DARWIN)
   add_definitions(-DNOUNCRYPT)
-  set(SRC ${SRC} minizip/ioapi.c minizip/unzip.c)
+  set(SRC ${SRC} signal-darwin.c minizip/ioapi.c minizip/unzip.c)
   set(OBJC_SRC JARURLProtocol.m)
   set(SRC ${SRC} ${OBJC_SRC})
   set(OBJC_FLAGS "-x objective-c")

--- a/compiler/vm/core/src/signal-darwin.c
+++ b/compiler/vm/core/src/signal-darwin.c
@@ -1,0 +1,5 @@
+// Weak stub has to be located in separate .o file. from place where its invoked
+#if defined(DARWIN)
+__attribute__ ((weak)) void registerDarwinExceptionHandler(void) {
+}
+#endif

--- a/compiler/vm/core/src/signal.c
+++ b/compiler/vm/core/src/signal.c
@@ -91,11 +91,7 @@ static void signalHandler_dump_thread(int signum, siginfo_t* info, void* context
 static jboolean installNoChainingSignals(Env* env);
 
 #if defined(DARWIN)
-// Weak stub for the function in vm/debug/src/debug.c. If librobovm-debug.a isn't
-// linked in this version will be used and won't do anything.
-void registerDarwinExceptionHandler(void) __attribute__ ((weak));
-void registerDarwinExceptionHandler(void) {
-}
+void registerDarwinExceptionHandler(void);
 #endif
 
 jboolean rvmInitSignals(Env* env) {

--- a/compiler/vm/debug/src/debug.c
+++ b/compiler/vm/debug/src/debug.c
@@ -16,7 +16,8 @@
 
 #if defined(DARWIN)
 
-#include <robovm.h>
+#include <pthread.h>
+#include <assert.h>
 #include <mach/mach.h>
 #include <mach/mach_error.h>
 #include <mach/exception.h>

--- a/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkAction.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkAction.java
@@ -72,10 +72,14 @@ public class CreateFrameworkAction extends AnAction {
     public static class FrameworkConfig {
         private final Module module;
         private final File destinationDir;
+        private final boolean debug;
+        private final boolean handleDarwinExceptions;
 
-        public FrameworkConfig(Module module, File destinationDir) {
+        public FrameworkConfig(Module module, File destinationDir, boolean debug, boolean handleDarwinExceptions) {
             this.module = module;
             this.destinationDir = destinationDir;
+            this.debug = debug;
+            this.handleDarwinExceptions = handleDarwinExceptions;
         }
 
         public Module getModule() {
@@ -84,6 +88,14 @@ public class CreateFrameworkAction extends AnAction {
 
         public File getDestinationDir() {
             return destinationDir;
+        }
+
+        public boolean isDebug() {
+            return debug;
+        }
+
+        public boolean isHandleDarwinExceptions() {
+            return handleDarwinExceptions;
         }
     }
 }

--- a/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkDialog.form
+++ b/plugins/idea/src/main/java/org/robovm/idea/actions/CreateFrameworkDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.robovm.idea.actions.CreateFrameworkDialog">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="632" height="185"/>
@@ -18,7 +18,7 @@
       </component>
       <vspacer id="1fdcd">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="386c1" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -58,6 +58,20 @@
       <component id="3c3f1" class="javax.swing.JComboBox" binding="module">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="5a5a3" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Build type"/>
+        </properties>
+      </component>
+      <component id="66691" class="javax.swing.JComboBox" binding="buildTypePicker">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
+++ b/plugins/idea/src/main/java/org/robovm/idea/compilation/RoboVmCompileTask.java
@@ -142,6 +142,8 @@ public class RoboVmCompileTask {
             // load the robovm.xml file
             loadConfig(project, builder, moduleBaseDir, false);
             builder.installDir(frameworkConfig.getDestinationDir());
+            builder.debug(frameworkConfig.isDebug());
+            builder.registerDarwinExceptionHandler(frameworkConfig.isHandleDarwinExceptions());
             configureClassAndSourcepaths(project, frameworkConfig.getModule(), builder);
 
             // Set the Home to be used, create the Config and AppCompiler


### PR DESCRIPTION
Using RoboVM applications in form of Framework has known issue: all NullPointerException even inside try/catch block will cause EXC_BAD_ACCESS and stop app in Xcode debugger. There is `debug.c` which registers Darwin exception handler that turns it into SIGSEGV which is handled by RoboVM signal handler. 

To do this with Framework target `librobovm-debug` has to be linked to framework build time. Changes adds Build Type selector to Create Framework dialog with options: Debug/Release/Release with debugger support. Others than Release add `librobovm-debug` to linker options. 

Also `registerDarwinExceptionHandler` moved to separated .o file, as substitution with strong implementation was not possible. (it was located in same file as usage and linker resolved weak implementation as one to be linked with)